### PR TITLE
Allow to pass custom environment to ffmpeg process

### DIFF
--- a/ffmpy.py
+++ b/ffmpy.py
@@ -68,7 +68,7 @@ class FFmpeg(object):
         process. By default no redirection is done, which means all output goes to running shell
         (this mode should normally only be used for debugging purposes). If FFmpeg ``pipe`` protocol
         is used for output, ``stdout`` must be redirected to a pipe by passing `subprocess.PIPE` as
-        ``stdout`` argument.
+        ``stdout`` argument. You can pass custom environment to ffmpeg process with ``env``.
 
         Returns a 2-tuple containing ``stdout`` and ``stderr`` of the process. If there was no
         redirection or if the output was redirected to e.g. `os.devnull`, the value returned will
@@ -83,6 +83,7 @@ class FFmpeg(object):
             redirection)
         :param stderr: redirect FFmpeg ``stderr`` there (default is `None` which means no
             redirection)
+        :param env: custom environment for ffmpeg process
         :return: a 2-tuple containing ``stdout`` and ``stderr`` of the process
         :rtype: tuple
         :raise: `FFRuntimeError` in case FFmpeg command exits with a non-zero code;

--- a/ffmpy.py
+++ b/ffmpy.py
@@ -60,7 +60,7 @@ class FFmpeg(object):
     def __repr__(self):
         return "<{0!r} {1!r}>".format(self.__class__.__name__, self.cmd)
 
-    def run(self, input_data=None, stdout=None, stderr=None):
+    def run(self, input_data=None, stdout=None, stderr=None, env=None):
         """Execute FFmpeg command line.
 
         ``input_data`` can contain input for FFmpeg in case ``pipe`` protocol is used for input.
@@ -90,7 +90,7 @@ class FFmpeg(object):
         """
         try:
             self.process = subprocess.Popen(
-                self._cmd, stdin=subprocess.PIPE, stdout=stdout, stderr=stderr
+                self._cmd, stdin=subprocess.PIPE, stdout=stdout, stderr=stderr, env=env
             )
         except OSError as e:
             if e.errno == errno.ENOENT:

--- a/tests/test_cmd_execution.py
+++ b/tests/test_cmd_execution.py
@@ -184,4 +184,6 @@ def test_custom_env(popen_mock):
     popen_mock.return_value.communicate.return_value = ('output', 'error')
     popen_mock.return_value.returncode = 0
     ff.run(env='customenv')
-    popen_mock.assert_called_with(mock.ANY, stdin=mock.ANY, stdout=mock.ANY, stderr=mock.ANY, env='customenv')
+    popen_mock.assert_called_with(
+        mock.ANY, stdin=mock.ANY, stdout=mock.ANY, stderr=mock.ANY, env='customenv'
+    )

--- a/tests/test_cmd_execution.py
+++ b/tests/test_cmd_execution.py
@@ -2,9 +2,9 @@ import os
 import subprocess
 import threading
 import time
+from unittest import mock
 
 import pytest
-from unittest import mock
 
 from ffmpy import FFExecutableNotFoundError, FFmpeg, FFRuntimeError
 
@@ -178,12 +178,12 @@ def test_terminate_process():
     assert ff.process.returncode == -15
 
 
-@mock.patch('ffmpy.subprocess.Popen')
+@mock.patch("ffmpy.subprocess.Popen")
 def test_custom_env(popen_mock):
     ff = FFmpeg()
-    popen_mock.return_value.communicate.return_value = ('output', 'error')
+    popen_mock.return_value.communicate.return_value = ("output", "error")
     popen_mock.return_value.returncode = 0
-    ff.run(env='customenv')
+    ff.run(env="customenv")
     popen_mock.assert_called_with(
-        mock.ANY, stdin=mock.ANY, stdout=mock.ANY, stderr=mock.ANY, env='customenv'
+        mock.ANY, stdin=mock.ANY, stdout=mock.ANY, stderr=mock.ANY, env="customenv"
     )

--- a/tests/test_cmd_execution.py
+++ b/tests/test_cmd_execution.py
@@ -4,6 +4,7 @@ import threading
 import time
 
 import pytest
+from unittest import mock
 
 from ffmpy import FFExecutableNotFoundError, FFmpeg, FFRuntimeError
 
@@ -175,3 +176,12 @@ def test_terminate_process():
     thread_1.join()
 
     assert ff.process.returncode == -15
+
+
+@mock.patch('ffmpy.subprocess.Popen')
+def test_custom_env(popen_mock):
+    ff = FFmpeg()
+    popen_mock.return_value.communicate.return_value = ('output', 'error')
+    popen_mock.return_value.returncode = 0
+    ff.run(env='customenv')
+    popen_mock.assert_called_with(mock.ANY, stdin=mock.ANY, stdout=mock.ANY, stderr=mock.ANY, env='customenv')


### PR DESCRIPTION
Hello. Here is my proposition for a new feature. I'm personally use it to set http proxy because ffmpeg `-http_proxy` option doesn't work for https urls via http proxy.