### PR TITLE
Added creationflags parameter to run() so that processes can gracefully killed on Windows.

### DIFF
--- a/ffmpy.py
+++ b/ffmpy.py
@@ -60,7 +60,7 @@ class FFmpeg(object):
     def __repr__(self):
         return "<{0!r} {1!r}>".format(self.__class__.__name__, self.cmd)
 
-    def run(self, input_data=None, stdout=None, stderr=None, env=None):
+    def run(self, input_data=None, stdout=None, stderr=None, env=None, creationflags=None):
         """Execute FFmpeg command line.
 
         ``input_data`` can contain input for FFmpeg in case ``pipe`` protocol is used for input.
@@ -91,7 +91,7 @@ class FFmpeg(object):
         """
         try:
             self.process = subprocess.Popen(
-                self._cmd, stdin=subprocess.PIPE, stdout=stdout, stderr=stderr, env=env
+                self._cmd, stdin=subprocess.PIPE, stdout=stdout, stderr=stderr, env=env, creationflags=creationflags
             )
         except OSError as e:
             if e.errno == errno.ENOENT:

--- a/ffmpy.py
+++ b/ffmpy.py
@@ -60,7 +60,7 @@ class FFmpeg(object):
     def __repr__(self):
         return "<{0!r} {1!r}>".format(self.__class__.__name__, self.cmd)
 
-    def run(self, input_data=None, stdout=None, stderr=None, env=None, creationflags=None):
+    def run(self, input_data=None, stdout=None, stderr=None, env=None, creationflags=subprocess.CREATE_NEW_CONSOLE):
         """Execute FFmpeg command line.
 
         ``input_data`` can contain input for FFmpeg in case ``pipe`` protocol is used for input.
@@ -84,6 +84,8 @@ class FFmpeg(object):
         :param stderr: redirect FFmpeg ``stderr`` there (default is `None` which means no
             redirection)
         :param env: custom environment for ffmpeg process
+        :param creationflags: determines how ffmpeg process is created (default is 'subprocess.CREATE_NEW_CONSOLE',
+            which creates a new console)
         :return: a 2-tuple containing ``stdout`` and ``stderr`` of the process
         :rtype: tuple
         :raise: `FFRuntimeError` in case FFmpeg command exits with a non-zero code;


### PR DESCRIPTION
Adds creationflags parameter to run() so that process can be optionally killed. Example code:

```
import ffmpy
from threading import Thread
import subprocess, time, signal, os

ff = ffmpy.FFmpeg(
    inputs={'in.mp4': None},
    outputs={'out.mp4' : None}
)

def execute():
    try:
        ff.run(creationflags=subprocess.CREATE_NEW_PROCESS_GROUP)
    except ffmpy.FFRuntimeError as ex:
        if ex.exit_code and ex.exit_code != 255:
            raise
    return

if __name__ == '__main__':
    process = Thread(target=execute)
    process.start()
    time.sleep(7)
    os.kill(self.ff.process.pid, signal.CTRL_BREAK_EVENT)
```