### PR TITLE
Remove reference to setuptools test command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from setuptools import setup
-from setuptools.command.test import test as TestCommand  # noqa
 
 from ffmpy import __version__
 


### PR DESCRIPTION
See https://github.com/pypa/setuptools/pull/4458

The command has been removed from latest version of setuptools (v72). Having this referenced in `setup.py` will cause installation of this package to fail with

```
ModuleNotFoundError: No module named 'setuptools.command.test'
```

(esp. when this package is not being distributed as a wheel -- please consider distributing this as a wheel on PyPI!)