### PR TITLE
Allow building with uv_build 0.8.*

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ warn_unreachable = true
 show_column_numbers = true
 
 [build-system]
-requires = ["uv_build>=0.7.9,<0.8.0"]
+requires = ["uv_build>=0.7.9,<0.9.0"]
 build-backend = "uv_build"
 
 [tool.uv.build-backend]


### PR DESCRIPTION
Tests pass with the exact same results as with uv_build 0.7.22:
`33 passed, 1 warning`

Arch Linux's `python-uv-build` is already `0.8.0-1` (released 4 days ago),
so building of [aur/python-ffmpy](https://aur.archlinux.org/packages/python-ffmpy) (which is, by the way, a dependency of [aur/python-gradio](https://aur.archlinux.org/packages/python-gradio)) fails without this one-line change.


Just in case, here's that 1 warning (my ffmpeg is 7.1.1):
```
=============================== warnings summary ===============================
tests/test_cmd_execution.py::test_terminate_process
  /usr/lib/python3.13/site-packages/_pytest/threadexception.py:58: PytestUnhandledThreadExceptionWarning: Exception in thread Thread-2 (run)
  
  Traceback (most recent call last):
    File "/usr/lib/python3.13/threading.py", line 1043, in _bootstrap_inner
      self.run()
      ~~~~~~~~^^
    File "/usr/lib/python3.13/threading.py", line 994, in run
      self._target(*self._args, **self._kwargs)
      ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/tmp/yay-arzeth/python-ffmpy/src/ffmpy-0.6.0/ffmpy/ffmpy.py", line 123, in run
      raise FFRuntimeError(self.cmd, self.process.returncode, o_stdout, o_stderr)
  ffmpy.ffmpy.FFRuntimeError: `ffmpeg --long-run` exited with status -15
  
  STDOUT:
  
  
  STDERR:
  
  
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
    warnings.warn(pytest.PytestUnhandledThreadExceptionWarning(msg))

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```